### PR TITLE
[gitignore] Ignore virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
+env/
+venv/
 __pycache__/
 .idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,6 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Topic :: Utilities"
 ]
-packages = [
-    { include = "pyimg4" }
-]
 
 [tool.poetry.scripts]
 pyimg4 = "pyimg4.__main__:cli"


### PR DESCRIPTION
This PR adds possible, common virtual environment names to `.gitignore`, preventing them from being committed on the repo. Other changes have been documented under the commit message.