### PR TITLE
IM4R rewrite

### DIFF
--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -54,7 +54,11 @@ class _PyIMG4:
 
 class _Property(_PyIMG4):
     def __init__(
-        self, data: Optional[bytes], *, fourcc: Optional[str] = None, value: Any = None
+        self,
+        data: Optional[bytes] = None,
+        *,
+        fourcc: Optional[str] = None,
+        value: Any = None,
     ) -> None:
         super().__init__(data)
 
@@ -67,6 +71,16 @@ class _Property(_PyIMG4):
 
         else:
             raise TypeError('No data or fourcc/value pair provided.')
+
+    def __repr__(self) -> str:
+        if not isinstance(self.value, (float, int)) and len(self.value) > 15:
+            value = f'{type(self.value).__name__} with len of {len(self.value)}'
+        elif isinstance(self.value, bytes):
+            value = self.value.hex()
+        else:
+            value = self.value
+
+        return f'{type(self).__name__}({self.fourcc}={value})'
 
     def _parse(self) -> None:
         self._decoder.start(self._data)
@@ -113,6 +127,9 @@ class _ImageData(_PyIMG4):
 
         if data is not None:
             self._parse()
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}(fourcc={self.fourcc})'
 
     def _parse(self) -> None:
         self._decoder.start(self._data)
@@ -188,15 +205,11 @@ class Data(_PyIMG4):
 
 
 class ManifestProperty(_Property):
-    def __repr__(self) -> str:
-        return f'ManifestProperty({self.name}={self.value})'
+    pass
 
 
 class ManifestImageData(_ImageData):
     _property = ManifestProperty
-
-    def __repr__(self) -> str:
-        return f'ManifestImageData(fourcc={self.fourcc})'
 
 
 class IM4M(_PyIMG4):
@@ -211,10 +224,10 @@ class IM4M(_PyIMG4):
     def __repr__(self) -> str:
         repr_ = f'IM4M('
         for p in ('CHIP', 'ECID'):
-            prop = next((prop for prop in self.properties if prop.name == p), None)
+            prop = next((prop for prop in self.properties if prop.fourcc == p), None)
 
             if prop is not None:
-                repr_ += f'{prop.name}={prop.value}, '
+                repr_ += f'{prop.fourcc}={prop.value}, '
 
         return repr_[:-2] + ')' if ',' in repr_ else repr_ + ')'
 
@@ -276,32 +289,32 @@ class IM4M(_PyIMG4):
     @property
     def apnonce(self) -> Optional[bytes]:
         return next(
-            (prop.value for prop in self.properties if prop.name == 'BNCH'),
+            (prop.value for prop in self.properties if prop.fourcc == 'BNCH'),
             None,
         )
 
     @property
     def board_id(self) -> Optional[int]:
         return next(
-            (prop.value for prop in self.properties if prop.name == 'BORD'), None
+            (prop.value for prop in self.properties if prop.fourcc == 'BORD'), None
         )
 
     @property
     def chip_id(self) -> Optional[int]:
         return next(
-            (prop.value for prop in self.properties if prop.name == 'CHIP'), None
+            (prop.value for prop in self.properties if prop.fourcc == 'CHIP'), None
         )
 
     @property
     def ecid(self) -> Optional[int]:
         return next(
-            (prop.value for prop in self.properties if prop.name == 'ECID'), None
+            (prop.value for prop in self.properties if prop.fourcc == 'ECID'), None
         )
 
     @property
     def sepnonce(self) -> Optional[bytes]:
         return next(
-            (prop.value for prop in self.properties if prop.name == 'snon'),
+            (prop.value for prop in self.properties if prop.fourcc == 'snon'),
             None,
         )
 

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -17,35 +17,6 @@ class _PyIMG4:
         self._decoder = asn1.Decoder()
         self._encoder = asn1.Encoder()
 
-
-def test_read_lzfse_enc(enc_lzfse: bytes) -> None:
-    im4p = pyimg4.IM4P(enc_lzfse)
-
-    assert im4p.fourcc == 'ibss'
-    assert im4p.description == 'iBoot-7429.12.15'
-
-    assert im4p.payload.encrypted == True
-    assert len(im4p.payload.keybags) == 2
-
-    assert im4p.payload.compression == pyimg4.Compression.LZFSE_ENCRYPTED
-
-    dec_kbag = pyimg4.Keybag(
-        iv=bytes.fromhex('0d0a39d2e3ea94f70076192e7d225e9e'),
-        key=bytes.fromhex(
-            '4567c8444b839a08b4a7c408531efb54ae69f1dcc24557ad0e21768b472f95cd'
-        ),
-    )
-
-    im4p.payload.decrypt(dec_kbag)
-
-    assert im4p.payload.compression == pyimg4.Compression.LZFSE
-
-    im4p.payload.decompress()
-
-    assert im4p.payload.compression == pyimg4.Compression.NONE
-
-    im4p.output()
-
     def __bytes__(self) -> bytes:
         return self.output()
 

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -74,7 +74,7 @@ class _Property(_PyIMG4):
 
     def __repr__(self) -> str:
         if not isinstance(self.value, (float, int)) and len(self.value) > 15:
-            value = f'{type(self.value).__name__} with len of {len(self.value)}'
+            value = f'<{type(self.value).__name__} with len of {len(self.value)}>'
         elif isinstance(self.value, bytes):
             value = self.value.hex()
         else:

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -209,6 +209,13 @@ class ManifestProperty(_Property):
 class ManifestImageData(_ImageData):
     _property = ManifestProperty
 
+    @property
+    def digest(self) -> Optional[bytes]:
+        return next(
+            (prop.value for prop in self.properties if prop.fourcc == 'DGST'),
+            None,
+        )
+
 
 class IM4M(_PyIMG4):
     def __init__(self, data: bytes) -> None:

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -329,11 +329,9 @@ class IM4R(_ImageData):
         data: Optional[bytes] = None,
         *,
         boot_nonce: Optional[bytes] = None,
-        properties: List[Optional[_property]] = [],
     ) -> None:
         super().__init__(data)
-
-        self.properties = properties
+        self.properties = list()
 
         if boot_nonce:
             self.boot_nonce = boot_nonce
@@ -577,11 +575,9 @@ class IM4P(_PyIMG4):
         fourcc: Optional[str] = None,
         description: Optional[str] = None,
         payload: Optional[Union['IM4PData', bytes]] = None,
-        properties: List[Optional[PayloadProperty]] = [],
     ) -> None:
         super().__init__(data)
-
-        self.properties = properties
+        self.properties = list()
 
         if data:
             self._parse()

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -63,8 +63,8 @@ class _Property(_PyIMG4):
         super().__init__(data)
 
         if fourcc and value:
-            self._verify_fourcc(fourcc)
-            self.fourcc = value
+            self.fourcc = self._verify_fourcc(fourcc)
+            self.value = value
 
         elif data:
             self._parse()
@@ -359,7 +359,7 @@ class IM4R(_ImageData):
         if len(boot_nonce) != 8:
             raise UnexpectedDataError('bytes with length of 8', boot_nonce)
 
-        prop = next((p.value for p in self.properties if prop.fourcc == 'BNCN'), None)
+        prop = next((p for p in self.properties if p.fourcc == 'BNCN'), None)
         if prop is not None:
             self.remove_property(prop)
 
@@ -384,6 +384,8 @@ class IM4R(_ImageData):
             if prop not in self.properties:
                 raise ValueError(f'Property "{prop.fourcc}" is not set')
 
+            self.properties.remove(prop)
+
         elif fourcc is not None:
             self._verify_fourcc(fourcc)
 
@@ -393,14 +395,14 @@ class IM4R(_ImageData):
             if prop is not None:
                 self.properties.remove(prop)
             else:
-                raise ValueError(f'Property "{fourcc}" not found')
+                raise ValueError(f'Property "{fourcc}" is not set')
 
     def output(self) -> bytes:
         self._encoder.start()
         self._encoder.enter(asn1.Numbers.Sequence, asn1.Classes.Universal)
 
         self._encoder.write(
-            self.fourcc,
+            'IM4R',
             asn1.Numbers.IA5String,
             asn1.Types.Primitive,
             asn1.Classes.Universal,

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -17,6 +17,35 @@ class _PyIMG4:
         self._decoder = asn1.Decoder()
         self._encoder = asn1.Encoder()
 
+
+def test_read_lzfse_enc(enc_lzfse: bytes) -> None:
+    im4p = pyimg4.IM4P(enc_lzfse)
+
+    assert im4p.fourcc == 'ibss'
+    assert im4p.description == 'iBoot-7429.12.15'
+
+    assert im4p.payload.encrypted == True
+    assert len(im4p.payload.keybags) == 2
+
+    assert im4p.payload.compression == pyimg4.Compression.LZFSE_ENCRYPTED
+
+    dec_kbag = pyimg4.Keybag(
+        iv=bytes.fromhex('0d0a39d2e3ea94f70076192e7d225e9e'),
+        key=bytes.fromhex(
+            '4567c8444b839a08b4a7c408531efb54ae69f1dcc24557ad0e21768b472f95cd'
+        ),
+    )
+
+    im4p.payload.decrypt(dec_kbag)
+
+    assert im4p.payload.compression == pyimg4.Compression.LZFSE
+
+    im4p.payload.decompress()
+
+    assert im4p.payload.compression == pyimg4.Compression.NONE
+
+    im4p.output()
+
     def __bytes__(self) -> bytes:
         return self.output()
 
@@ -375,7 +404,7 @@ class IM4R(_ImageData):
         self.properties.append(prop)
 
     def remove_property(
-        self, prop: Optional[_property], fourcc: Optional[str] = None
+        self, prop: Optional[_property] = None, fourcc: Optional[str] = None
     ) -> None:
         if prop is not None:
             if not isinstance(prop, self._property):
@@ -734,7 +763,7 @@ class IM4P(_PyIMG4):
         self.properties.append(prop)
 
     def remove_property(
-        self, prop: Optional[PayloadProperty], fourcc: Optional[str] = None
+        self, prop: Optional[PayloadProperty] = None, fourcc: Optional[str] = None
     ) -> None:
         if prop is not None:
             if not isinstance(prop, PayloadProperty):

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -334,20 +334,12 @@ class IM4R(_ImageData):
     def __init__(
         self,
         data: Optional[bytes] = None,
-        *,
-        boot_nonce: Optional[bytes] = None,
     ) -> None:
         super().__init__(data)
         self.properties = list()
 
-        if boot_nonce:
-            self.boot_nonce = boot_nonce
-
-        elif data:
+        if data:
             self._parse()
-
-        else:
-            raise TypeError('No data or boot nonce provided.')
 
     @property
     def boot_nonce(self) -> Optional[bytes]:
@@ -403,6 +395,9 @@ class IM4R(_ImageData):
                 raise ValueError(f'Property "{fourcc}" is not set')
 
     def output(self) -> bytes:
+        if len(self.properties) == 0:
+            raise ValueError('No properties set')
+
         self._encoder.start()
         self._encoder.enter(asn1.Numbers.Sequence, asn1.Classes.Universal)
 

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -738,7 +738,7 @@ class IM4P(_PyIMG4):
     ) -> None:
         if prop is not None:
             if not isinstance(prop, PayloadProperty):
-                raise UnexpectedDataError(PayloadProperty.__name__, prop)
+                raise UnexpectedDataError('PayloadProperty', prop)
 
             if prop not in self.properties:
                 raise ValueError(f'Property "{prop.fourcc}" is not set')

--- a/pyimg4/_parser.py
+++ b/pyimg4/_parser.py
@@ -341,6 +341,9 @@ class IM4R(_ImageData):
         if data:
             self._parse()
 
+    def __repr__(self) -> str:
+        return f'IM4R(properties={len(self.properties)})'
+
     @property
     def boot_nonce(self) -> Optional[bytes]:
         return next(

--- a/pyimg4/errors.py
+++ b/pyimg4/errors.py
@@ -18,9 +18,11 @@ class CompressionError(_PyIMG4Error):
 class UnexpectedDataError(_PyIMG4Error, ValueError):
     def __init__(self, expect: str, real: Any) -> NoReturn:
         if not isinstance(real, (float, int)) and len(real) > 15:
-            real = f'{type(real).__name__} with len of {len(real)}'
+            real = f'<{type(real).__name__} with len of {len(real)}>'
 
-        super().__init__(f"Expected data: {expect}, got: {real if not isinstance(real, bytes) else real.hex()}")
+        super().__init__(
+            f"Expected data: {expect}, got: {real if not isinstance(real, bytes) else real.hex()}"
+        )
 
 
 class UnexpectedTagError(_PyIMG4Error, ValueError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from random import getrandbits
 
 import pytest
 from remotezip import RemoteZip
@@ -7,33 +6,40 @@ from remotezip import RemoteZip
 LZSS_DEC_IPSW = 'https://updates.cdn-apple.com/2021FallFCS/fullrestores/002-03194/8EC63AF9-19BE-4829-B389-27AECB41DD6A/iPhone_5.5_15.0_19A346_Restore.ipsw'
 LZSS_ENC_IPSW = 'http://appldnld.apple.com/iOS9.3.5/031-73130-20160825-6A2C2FD4-6711-11E6-B3F4-173834D2D062/iPhone8,2_9.3.5_13G36_Restore.ipsw'
 LZFSE_IPSW = 'https://updates.cdn-apple.com/2021FallFCS/fullrestores/002-02910/AF984499-D03A-43E7-9472-6D16BA756E5E/iPhone10,3,iPhone10,6_15.0_19A346_Restore.ipsw'
+PAYP_IPSW = 'https://updates.cdn-apple.com/2022FallFCS/fullrestores/032-11449/3995EAD9-8F0E-491E-BEC8-C97B6B1845C7/iPhone15,3_16.1.2_20B110_Restore.ipsw'
 
 
-@pytest.fixture(name='dec_lzss', scope='session')
+@pytest.fixture(name='DEC_LZSS_IM4P', scope='session')
 def fetch_dec_lzss_im4p() -> bytes:
     with RemoteZip(LZSS_DEC_IPSW) as ipsw:
         return ipsw.read('kernelcache.release.n66')
 
 
-@pytest.fixture(name='dec_lzfse', scope='session')
-def fetch_dec_lzfse_im4p() -> bytes:
-    with RemoteZip(LZFSE_IPSW) as ipsw:
-        return ipsw.read('kernelcache.release.iphone10b')
-
-
-@pytest.fixture(name='enc_lzss', scope='session')
+@pytest.fixture(name='ENC_LZSS_IM4P', scope='session')
 def fetch_enc_lzss_im4p() -> bytes:
     with RemoteZip(LZSS_ENC_IPSW) as ipsw:
         return ipsw.read('kernelcache.release.n66')
 
 
-@pytest.fixture(name='enc_lzfse', scope='session')
+@pytest.fixture(name='DEC_LZFSE_IM4P', scope='session')
+def fetch_dec_lzfse_im4p() -> bytes:
+    with RemoteZip(LZFSE_IPSW) as ipsw:
+        return ipsw.read('kernelcache.release.iphone10b')
+
+
+@pytest.fixture(name='ENC_LZFSE_IM4P', scope='session')
 def fetch_enc_lzfse_im4p() -> bytes:
     with RemoteZip(LZFSE_IPSW) as ipsw:
         return ipsw.read('Firmware/dfu/iBSS.d22.RELEASE.im4p')
 
 
-@pytest.fixture(name='test_data', scope='session')
+@pytest.fixture(name='PAYP_IM4P', scope='session')
+def fetch_payp_im4p() -> bytes:
+    with RemoteZip(PAYP_IPSW) as ipsw:
+        return ipsw.read('Firmware/dfu/iBSS.d74.RELEASE.im4p')
+
+
+@pytest.fixture(name='TEST_PAYLOAD', scope='session')
 def fetch_test_payload() -> bytes:
     with (Path(__file__).parent / 'bin' / 'test_payload').open('rb') as f:
         return f.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,3 @@ def read_im4p() -> bytes:
 def read_im4r() -> bytes:
     with (Path(__file__).parent / 'bin' / 'IM4R').open('rb') as f:
         return f.read()
-
-
-@pytest.fixture(name='boot_nonce', scope='session')
-def random_boot_nonce() -> bytes:
-    return getrandbits(64).to_bytes(8, 'big')

--- a/tests/test_im4p.py
+++ b/tests/test_im4p.py
@@ -3,10 +3,10 @@ import pytest
 import pyimg4
 
 
-def test_create(test_data: bytes, IM4P: bytes) -> None:
+def test_create(TEST_PAYLOAD: bytes, IM4P: bytes) -> None:
     im4p = pyimg4.IM4P()
 
-    im4p.payload = test_data
+    im4p.payload = TEST_PAYLOAD
 
     im4p.fourcc = 'test'
 
@@ -18,8 +18,8 @@ def test_create(test_data: bytes, IM4P: bytes) -> None:
     assert im4p == IM4P
 
 
-def test_read_lzss_dec(dec_lzss: bytes) -> None:
-    im4p = pyimg4.IM4P(dec_lzss)
+def test_read_lzss_dec(DEC_LZSS_IM4P: bytes) -> None:
+    im4p = pyimg4.IM4P(DEC_LZSS_IM4P)
 
     assert im4p.fourcc == 'krnl'
     assert im4p.description == 'KernelCacheBuilder_release-2238.10.3'
@@ -36,23 +36,8 @@ def test_read_lzss_dec(dec_lzss: bytes) -> None:
     im4p.output()
 
 
-def test_read_lzfse_dec(dec_lzfse: bytes) -> None:
-    im4p = pyimg4.IM4P(dec_lzfse)
-
-    assert im4p.fourcc == 'krnl'
-    assert im4p.description == 'KernelCacheBuilder_release-2238.10.3'
-
-    assert im4p.payload.compression == pyimg4.Compression.LZFSE
-
-    im4p.payload.decompress()
-
-    assert im4p.payload.compression == pyimg4.Compression.NONE
-
-    im4p.output()
-
-
-def test_read_lzss_enc(enc_lzss: bytes) -> None:
-    im4p = pyimg4.IM4P(enc_lzss)
+def test_read_lzss_enc(ENC_LZSS_IM4P: bytes) -> None:
+    im4p = pyimg4.IM4P(ENC_LZSS_IM4P)
 
     assert im4p.fourcc == 'krnl'
     assert im4p.description == 'KernelCacheBuilder-960.40.11'
@@ -81,8 +66,23 @@ def test_read_lzss_enc(enc_lzss: bytes) -> None:
     im4p.output()
 
 
-def test_read_lzfse_enc(enc_lzfse: bytes) -> None:
-    im4p = pyimg4.IM4P(enc_lzfse)
+def test_read_lzfse_dec(DEC_LZFSE_IM4P: bytes) -> None:
+    im4p = pyimg4.IM4P(DEC_LZFSE_IM4P)
+
+    assert im4p.fourcc == 'krnl'
+    assert im4p.description == 'KernelCacheBuilder_release-2238.10.3'
+
+    assert im4p.payload.compression == pyimg4.Compression.LZFSE
+
+    im4p.payload.decompress()
+
+    assert im4p.payload.compression == pyimg4.Compression.NONE
+
+    im4p.output()
+
+
+def test_read_lzfse_enc(ENC_LZFSE_IM4P: bytes) -> None:
+    im4p = pyimg4.IM4P(ENC_LZFSE_IM4P)
 
     assert im4p.fourcc == 'ibss'
     assert im4p.description == 'iBoot-7429.12.15'
@@ -106,5 +106,22 @@ def test_read_lzfse_enc(enc_lzfse: bytes) -> None:
     im4p.payload.decompress()
 
     assert im4p.payload.compression == pyimg4.Compression.NONE
+
+    im4p.output()
+
+
+def test_read_payp(PAYP_IM4P: bytes) -> None:
+    im4p = pyimg4.IM4P(PAYP_IM4P)
+
+    assert im4p.fourcc == 'ibss'
+    assert im4p.description == 'iBoot-8419.40.112'
+
+    assert im4p.payload.encrypted == True
+    assert len(im4p.payload.keybags) == 2
+
+    assert im4p.payload.compression == pyimg4.Compression.LZFSE_ENCRYPTED
+
+    assert len(im4p.properties) == 2
+    assert any(prop.fourcc not in ('mmap', 'rddg') for prop in im4p.properties) == False
 
     im4p.output()

--- a/tests/test_im4r.py
+++ b/tests/test_im4r.py
@@ -3,8 +3,8 @@ import pytest
 import pyimg4
 
 
-def test_create(boot_nonce: bytes) -> None:
-    im4r = pyimg4.IM4R(boot_nonce=boot_nonce)
+def test_create() -> None:
+    im4r = pyimg4.IM4R()
 
     im4r.boot_nonce = bytes.fromhex('1234567890123456')
 


### PR DESCRIPTION
This PR will allow for `pyimg4.IM4R` to support properties other than `BNCN` (the boot nonce generator), as this is now a requirement for iPhone 14 series restores (https://github.com/libimobiledevice/idevicerestore/issues/532#issuecomment-1261891286). This will change how `pyimg4.IM4R` works internally, essentially having it work similarly to `pyimg4.ManifestImageData`.

As `pyimg4.ManifestImageData` and `pyimg4.IM4R` will now share much of the same codebase, `pyimg4.ManifestImageData` and `pyimg4.ManifestProperty` will be converted to private classes and subclassed. `pyimg4.IM4R` will also use these internal classes, and store properties (such as `BNCN`, `ucon`, and `ucer`) under `pyimg4.IM4R.properties`.

Update: Conveniently, I found out I can also replace `IM4PProperties` with a subclass of the internal property class, so now IM4P payload properties will be fully parsed/modifiable in this PR as well. 

This PR closes #17 and #19.