### PR TITLE
requirements: Add `asn1<3.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "asn1>=2.7.0",
+    "asn1<3.0.0",
     "click>=8.1.7",
     "pycryptodome>=3.18.0",
     "pylzss==0.3.4",


### PR DESCRIPTION
Version 3.0.0 is technically much better, but pyimg4 should be refactored around it first to support it.